### PR TITLE
Add missing base_url for production

### DIFF
--- a/configurations/production.yaml
+++ b/configurations/production.yaml
@@ -1,5 +1,6 @@
 application:
   host: 0.0.0.0
+  base_url: "https://zero2prod-mnodh.ondigitalocean.app"
 database:
   require_ssl: true
 email_client:


### PR DESCRIPTION
App crashed on production:
[2024-07-05 16:54:41] base_path: Some("/app")
[2024-07-05 16:54:41] thread 'main' panicked at src/main.rs:10:45: [2024-07-05 16:54:41] Failed to read configuration: missing field `base_url` [2024-07-05 16:54:41] note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace